### PR TITLE
DBZ-3482 Add missing format model

### DIFF
--- a/debezium-server/debezium-server-pravega/src/main/java/io/debezium/server/pravega/PravegaChangeConsumer.java
+++ b/debezium-server/debezium-server-pravega/src/main/java/io/debezium/server/pravega/PravegaChangeConsumer.java
@@ -49,7 +49,7 @@ public class PravegaChangeConsumer extends BaseChangeConsumer implements ChangeC
     @ConfigProperty(name = PROP_SCOPE)
     String scope;
 
-    @ConfigProperty(name = PROP_TXN)
+    @ConfigProperty(name = PROP_TXN, defaultValue = "false")
     boolean txn;
 
     private ClientConfig clientConfig;


### PR DESCRIPTION
When the format model is omitted, the default is used. The default is determined from NLS settings