### PR TITLE
[docs] Restore downstream ModuleID declaration

### DIFF
--- a/debezium-server/debezium-server-pravega/src/main/java/io/debezium/server/pravega/PravegaChangeConsumer.java
+++ b/debezium-server/debezium-server-pravega/src/main/java/io/debezium/server/pravega/PravegaChangeConsumer.java
@@ -49,7 +49,7 @@ public class PravegaChangeConsumer extends BaseChangeConsumer implements ChangeC
     @ConfigProperty(name = PROP_SCOPE)
     String scope;
 
-    @ConfigProperty(name = PROP_TXN)
+    @ConfigProperty(name = PROP_TXN, defaultValue = "false")
     boolean txn;
 
     private ClientConfig clientConfig;


### PR DESCRIPTION
Restore the downstream comment that specifies the downstream anchor ID for the snapshots topic. I previously removed the comment, because downstream, links to the topic were not working. A tooling change should address this deficit without requiring us to remove further ModuleIDs.

This change is not visible in either the upstream or downstream content and has no effect on the upstream behavior.