### PR TITLE
DBZ-3631 Align Xstream to emit null when BLOB/CLOB fields are set to …

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -318,16 +318,19 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         for (ChunkColumnValue chunkValue : chunkValues) {
             data.append(chunkValue.getColumnData().stringValue());
         }
-        return data.toString();
+        return data.length() == 0 ? null : data.toString();
     }
 
     private byte[] resolveBlobChunkValue(List<ChunkColumnValue> chunkValues) {
         long size = chunkValues.stream().map(ChunkColumnValue::getColumnData).mapToLong(Datum::getLength).sum();
-        ByteBuffer buffer = ByteBuffer.allocate((int) size);
-        for (ChunkColumnValue columnValue : chunkValues) {
-            buffer.put(columnValue.getColumnData().getBytes());
+        if (size > 0) {
+            ByteBuffer buffer = ByteBuffer.allocate((int) size);
+            for (ChunkColumnValue columnValue : chunkValues) {
+                buffer.put(columnValue.getColumnData().getBytes());
+            }
+            return buffer.array();
         }
-        return buffer.array();
+        return null;
     }
 
     @Override


### PR DESCRIPTION
…null.

While LogMiner already did this, the Xstream implementation was not checking for
this use case and was instead emitting empty strings or empty byte buffer values
rather than explicit nulls if there was no data.